### PR TITLE
Fix: disabled scroll to top on chaging filters

### DIFF
--- a/app/(routes)/category/[categoryId]/components/filter.tsx
+++ b/app/(routes)/category/[categoryId]/components/filter.tsx
@@ -22,7 +22,7 @@ const Filter: React.FC<FilterProps> = ({
   const router = useRouter();
 
   const selectedValue = searchParams.get(valueKey);
-  
+
   const onClick = (id: string) => {
     const current = qs.parse(searchParams.toString());
 
@@ -40,10 +40,10 @@ const Filter: React.FC<FilterProps> = ({
       query,
     }, { skipNull: true });
 
-    router.push(url);
+    router.push(url, { scroll: false });
   }
 
-  return ( 
+  return (
     <div className="mb-8">
       <h3 className="text-lg font-semibold">
         {name}


### PR DESCRIPTION
## What?

**I disabled the annoying scroll to the top when using filters.**

![Untitled video - Made with Clipchamp](https://github.com/AntonioErdeljac/next13-ecommerce-store/assets/83113185/8b7014ab-c935-493c-86dc-9e08cf8b135b)

## Why?
Because it's annoying and hampers the user experience.

## How?
`router.push(url, as, options)`
- `options:{scroll,shallow,locale}`
> `scroll` - Optional boolean, controls scrolling to the top of the page after navigation. Defaults to `true`

[Check useRouter Docs by NextJS](https://nextjs.org/docs/pages/api-reference/functions/use-router#routerpush) 