### PR TITLE
Fix overload error for zustand/persist usage

### DIFF
--- a/hooks/use-cart.tsx
+++ b/hooks/use-cart.tsx
@@ -1,9 +1,8 @@
-import { create } from 'zustand';
+import { create, StateCreator } from 'zustand';
 import { toast } from 'react-hot-toast';
-import { persist, createJSONStorage } from "zustand/middleware"; 
+import { persist, createJSONStorage, PersistOptions } from 'zustand/middleware';
 
 import { Product } from '@/types';
-import { AlertTriangle } from 'lucide-react';
 
 interface CartStore {
   items: Product[];
@@ -11,29 +10,37 @@ interface CartStore {
   removeItem: (id: string) => void;
   removeAll: () => void;
 }
+type MyPersist = (
+  config: StateCreator<CartStore>,
+  options: PersistOptions<CartStore>
+) => StateCreator<CartStore>;
 
-const useCart = create(
-  persist<CartStore>((set, get) => ({
-  items: [],
-  addItem: (data: Product) => {
-    const currentItems = get().items;
-    const existingItem = currentItems.find((item) => item.id === data.id);
-    
-    if (existingItem) {
-      return toast('Item already in cart.');
+const useCart = create<CartStore, []>(
+  (persist as MyPersist)(
+    (set, get): CartStore => ({
+      items: [],
+      addItem: (data: Product) => {
+        const currentItems = get().items;
+        const existingItem = currentItems.find((item) => item.id === data.id);
+
+        if (existingItem) {
+          return toast('Item already in cart.');
+        }
+
+        set({ items: [...get().items, data] });
+        toast.success('Item added to cart.');
+      },
+      removeItem: (id: string) => {
+        set({ items: [...get().items.filter((item) => item.id !== id)] });
+        toast.success('Item removed from cart.');
+      },
+      removeAll: () => set({ items: [] }),
+    }),
+    {
+      name: 'cart-storage',
+      storage: createJSONStorage(() => localStorage),
     }
-
-    set({ items: [...get().items, data] });
-    toast.success('Item added to cart.');
-  },
-  removeItem: (id: string) => {
-    set({ items: [...get().items.filter((item) => item.id !== id)] });
-    toast.success('Item removed from cart.');
-  },
-  removeAll: () => set({ items: [] }),
-}), {
-  name: 'cart-storage',
-  storage: createJSONStorage(() => localStorage)
-}));
+  )
+);
 
 export default useCart;


### PR DESCRIPTION
This pull request fixes an overload error that occurred when using the zustand/persist plugin with a custom store creator. The error was caused by a type mismatch between the $$storeMutators property of the store creator and the expected type of the argument to the UseBoundStore hook.

This fix ensures that the zustand/persist plugin can be used with custom store creators without causing any type errors.

Here is the warning:
```
No overload matches this call.
  Overload 1 of 3, '(initializer: StateCreator<never, [], [never, unknown][]>): UseBoundStore<StoreApi<never>>', gave the following error.
    Argument of type 'StateCreator<never, [], [["zustand/persist", never]]>' is not assignable to parameter of type 'StateCreator<never, [], [never, unknown][]>'.
      Type 'StateCreator<never, [], [["zustand/persist", never]]>' is not assignable to type '{ $$storeMutators?: [never, unknown][] | undefined; }'.
        Types of property '$$storeMutators' are incompatible.
          Type '[["zustand/persist", never]] | undefined' is not assignable to type '[never, unknown][] | undefined'.
            Type '[["zustand/persist", never]]' is not assignable to type '[never, unknown][]'.
              Type '["zustand/persist", never]' is not assignable to type '[never, unknown]'.
                Type at position 0 in source is not compatible with type at position 0 in target.
                  Type 'string' is not assignable to type 'never'.
  Overload 2 of 3, '(store: StoreApi<unknown>): UseBoundStore<StoreApi<unknown>>', gave the following error.
    Argument of type 'StateCreator<never, [], [["zustand/persist", never]]>' is not assignable to parameter of type 'StoreApi<unknown>'.ts(2769)
```